### PR TITLE
Using JSON.stringify() on a DOM element can have circular references. This has been changed to use outerHTML.

### DIFF
--- a/src/utils/imageLoader.js
+++ b/src/utils/imageLoader.js
@@ -46,6 +46,6 @@ export default async function imageLoader(target: any) {
 
     applyImage.apply(this, [target, image, src]);
   } catch (e) {
-    throw new Error(`💩 Fetch image failed with target ${JSON.stringify(target, null, 2)} and error message ${e}`);
+    throw new Error(`💩 Fetch image failed with target\n\n${target.outerHTML}\n\nand error message ${e}`);
   }
 }


### PR DESCRIPTION
Using JSON.stringify() on a DOM element can have circular references. This has been changed to use outerHTML.