### PR TITLE
Check component is mounted before async setState

### DIFF
--- a/src/simpleImg.js
+++ b/src/simpleImg.js
@@ -58,15 +58,18 @@ export class SimpleImg extends React.PureComponent<Props, State> {
     loaded: false,
     isDocumentLoad: false,
   };
-
+  _isMounted = false;
   componentDidMount() {
+    this._isMounted = true;
     if (document.readyState === 'complete') {
       window.__REACT_SIMPLE_IMG__.observer.observe(this.element.current);
     } else {
       window.addEventListener('load', () => {
-        this.setState({
-          isDocumentLoad: true,
-        });
+        if(this._isMounted){
+          this.setState({
+            isDocumentLoad: true,
+          });
+        }
       });
     }
   }
@@ -102,6 +105,7 @@ export class SimpleImg extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     if (!this.element.current) return;
     const { removeImgLoadingRef, removeImageRef, useContext } = this.props;
     const element = this.element.current;


### PR DESCRIPTION
I got a warning while using this library. Check whether the component is mounted before we callback with a setState call. This 

```
Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method. in SimpleImg (created by Context.Consumer)
```