### PR TITLE
Move `noscript` position and add `imgStyle` into fallback `<img />`

### DIFF
--- a/src/simpleImg.js
+++ b/src/simpleImg.js
@@ -162,13 +162,14 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
     };
     const noScript = (
       <noscript>
-        <img src={src} alt={alt} />
+        <img src={src} alt={alt} style={imgStyle} />
       </noscript>
     );
 
     if (disablePlaceholder && !applyAspectRatio) {
       return (
         <React.Fragment>
+          {noScript}
           <img
             style={{
               ...style,
@@ -184,7 +185,6 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
             {...heightWidth}
             {...imageProps}
           />
-          {noScript}
         </React.Fragment>
       );
     }
@@ -234,6 +234,7 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
         }}
         className={className}
       >
+        {noScript}
         <img
           style={{
             ...(isHeightAndWidthNotSet ? expendWidth : heightWidth),
@@ -250,7 +251,6 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
           {...imageProps}
         />
         {!disablePlaceholder && placeholderComponent}
-        {noScript}
       </div>
     );
   }


### PR DESCRIPTION
Hey @bluebill1049, first of all thanks for this cool _library_.

I found some _issues_ regarding the `<noscript>` part and hope could be useful for every _use case_.

The point is that checking the cases where `<noscript>` should be available as _fallback_, since is rendered after the regular `<img />`, both as `relative` positioned elements, the fallback one remains outside the _wrapper_ which has `overflow: hidden` styles. Swapping the order, in that case, the regular `img` (not needed) remains overflown.

The other point is to pass also `imgStyles` to the _fallback_ `img` to have the same _look and feel_ as the regular one.

Let me know in any case,