### PR TITLE
fix: image classname on <noscript> img

### DIFF
--- a/src/simpleImg.js
+++ b/src/simpleImg.js
@@ -162,7 +162,7 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
     };
     const noScript = (
       <noscript>
-        <img src={src} alt={alt} style={imgStyle} />
+        <img src={src} alt={alt} style={imgStyle} className={className} />
       </noscript>
     );
 


### PR DESCRIPTION
Preserve inferred class names on `<noscript>` images that are passed from props. 

Keeps styling consistent for SSR when users/bots do not have javascript enabled.