### PR TITLE
Handle errors thrown when trying to use sessionStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Arguments
 
 
      - if you want to disable the reveal animation after image have been cached
+     - Determining whether images have been cached is achieved using `sessionStorage`.
+       Setting this to true will have no effect for users with privacy settings enabled 
+       in their browsers that block the use of `sessionStorage`.
+        
+     
 
 - **logConsoleError**: (boolean) this argument is <b>optional</b>
 

--- a/src/logic/updateSessionStorage.js
+++ b/src/logic/updateSessionStorage.js
@@ -1,7 +1,12 @@
 // @flow
+import logError from '../utils/logError';
 
 export default function updateSessionStorage(src: string) {
-  const cachedImages = JSON.parse(window.sessionStorage.getItem('__REACT_SIMPLE_IMG__')) || {};
-  cachedImages[src] = +new Date();
-  window.sessionStorage.setItem('__REACT_SIMPLE_IMG__', JSON.stringify(cachedImages));
+  try {
+    const cachedImages = JSON.parse(window.sessionStorage.getItem('__REACT_SIMPLE_IMG__')) || {};
+    cachedImages[src] = +new Date();
+    window.sessionStorage.setItem('__REACT_SIMPLE_IMG__', JSON.stringify(cachedImages));
+  } catch (e) {
+    logError(`Error marking image as cached ${e}`);
+  }
 }

--- a/src/simpleImg.js
+++ b/src/simpleImg.js
@@ -38,19 +38,20 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const cachedImagesRefString = window.sessionStorage.getItem('__REACT_SIMPLE_IMG__');
     const { src } = this.props;
     const element = this.element.current;
 
     if (
-      cachedImagesRefString &&
       window.__REACT_SIMPLE_IMG__.disableAnimateCachedImg &&
       element
       // && element.getAttribute('data-from-server') === 'no'
     ) {
       try {
-        const cachedImagesRef = JSON.parse(cachedImagesRefString);
+        // Browsers with strict privacy settings could throw an error when
+        // attempting to use localStorage and sessionStorage.
+        const cachedImagesRefString = window.sessionStorage.getItem('__REACT_SIMPLE_IMG__');
 
+        const cachedImagesRef = JSON.parse(cachedImagesRefString) || {};
         if (cachedImagesRef[src]) {
           this.setState({
             isCached: true,
@@ -58,7 +59,7 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
           return;
         }
       } catch (e) {
-        logError(`JSON parsing is broken ${e}`);
+        logError(`Error retrieving cached images ${e}`);
       }
     }
 


### PR DESCRIPTION
* Some browsers have settings which users can enable that block the use of `sessionStorage`.
* See https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document for an example
* To fix this, let's try-catch the usages of `sessionStorage`, as it appears to only be needed to enable the non-essential configuration option that disables animation for cached images