### PR TITLE
Fixes an issue where SSR HTML output contained an empty srcSet attribute

### DIFF
--- a/src/simpleImg.js
+++ b/src/simpleImg.js
@@ -149,7 +149,7 @@ export default class SimpleImg extends React.PureComponent<Props, State> {
     const imageProps = {
       alt,
       src: isCached ? src : imgPlaceholder,
-      srcSet: isCached ? srcSet : '',
+      srcSet: isCached ? srcSet : null,
       // 'data-from-server': typeof window === 'undefined' ? 'yes' : 'no',
       ...(isCached
         ? null

--- a/test/__snapshots__/simpleImg.test.js.snap
+++ b/test/__snapshots__/simpleImg.test.js.snap
@@ -29,7 +29,6 @@ exports[`SimpleImg should apply aspect ratio when height and width is supplied 1
     data-srcset="srcSet"
     sizes="sizes"
     src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-    srcSet=""
     style={
       Object {
         "visibility": "hidden",
@@ -82,7 +81,6 @@ exports[`SimpleImg should render background color 1`] = `
     data-srcset="srcSet"
     sizes="sizes"
     src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-    srcSet=""
     style={
       Object {
         "visibility": "hidden",
@@ -135,7 +133,6 @@ exports[`SimpleImg should render correctly 1`] = `
     data-srcset="srcSet"
     sizes="sizes"
     src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-    srcSet=""
     style={
       Object {
         "visibility": "hidden",
@@ -176,7 +173,6 @@ Array [
     data-srcset="srcSet"
     sizes="sizes"
     src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-    srcSet=""
     style={
       Object {
         "opacity": 0,
@@ -216,7 +212,6 @@ exports[`SimpleImg should render only span when place holder src is not supplied
     data-srcset="srcSet"
     sizes="sizes"
     src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-    srcSet=""
     style={
       Object {
         "visibility": "hidden",
@@ -269,7 +264,6 @@ exports[`SimpleImg should render out as image data 1`] = `
     data-srcset="srcSet"
     sizes="sizes"
     src="data:image//test"
-    srcSet=""
     style={
       Object {
         "width": "100%",
@@ -322,7 +316,6 @@ exports[`SimpleImg should render out placeholder as image 1`] = `
     data-srcset="srcSet"
     sizes="sizes"
     src="/test/image.jpg"
-    srcSet=""
     style={
       Object {
         "width": "100%",


### PR DESCRIPTION
This is an issue as a) the browser might block and attempt to render the img, and b) this is invalid HTML (per the HTML5 spec).

Tested and working on SSR environment Gatsby

Fixes #85 