### PR TITLE
fix 'importance' property type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ export interface Props {
   srcSet?: string;
   style?: React.CSSProperties;
   animationDuration?: number;
-  importance?: "low" | "high";
+  importance?: "low" | "auto";
   onComplete?: VoidFunction;
   imgStyle?: React.CSSProperties;
 }

--- a/src/simpleImg.flow.js
+++ b/src/simpleImg.flow.js
@@ -18,7 +18,7 @@ export type Props = {
   srcSet?: string,
   style?: Style,
   animationDuration?: number,
-  importance?: 'low' | 'high',
+  importance?: 'low' | 'auto',
   onComplete?: () => void,
   imgStyle: Style,
 };


### PR DESCRIPTION
Hello!
Thank you for such a great library, it helps me to load images easy.
I guess I just noticed some typo in types.

According to readme.md and source code we can use importance property with "low" or "auto" value, but in types we have only 'low' and 'high' possibilities.